### PR TITLE
Finish syncing data across tabs and with CF API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 - [x] Implement the question suggestion algorithm (should adjust the estimated Elo on whether a user can solve it and their attempts)
 - [x] Add problem refresh
 - [x] Suggestion Problems - Implement topic targetted & Elo targetted
-- [ ] Get started with BullMQ task schedulers to constantly update information of users and questions if data is too old (updating every day)
+- [x] Get started with BullMQ task schedulers to constantly update information of users and questions if data is too old (updating every day)
 
 ### Week 7
-- [ ] Finish task schedulers if necessary
+- [x] Finish task schedulers if necessary
 - [ ] Create a questions list with Elo, topic tags, and link them to said questions. Implement search, sorts, and filters. Update status of question if solved
 - [ ] Get starteted with resources board
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 - [x] Create submission stats (attempts, AC, percentages)
 
 ### Week 6
-- [ ] Implement the question suggestion algorithm (should adjust the estimated Elo on whether a user can solve it and their attempts)
-- [ ] Add problem refresh
-- [ ] Suggestion Problems - Implement topic targetted & Elo targetted
+- [x] Implement the question suggestion algorithm (should adjust the estimated Elo on whether a user can solve it and their attempts)
+- [x] Add problem refresh
+- [x] Suggestion Problems - Implement topic targetted & Elo targetted
 - [ ] Get started with BullMQ task schedulers to constantly update information of users and questions if data is too old (updating every day)
 
 ### Week 7

--- a/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
+++ b/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import API from "../../../api.js";
 import propTypes from "prop-types";
 
 LinkCodeforcesAccount.propTypes = {
     profileUsername: propTypes.string.isRequired,
     JWT: propTypes.string.isRequired,
+    linkResponse: propTypes.object.isRequired,
 };
 
 function LinkCodeforcesAccount(props) {
@@ -18,27 +19,34 @@ function LinkCodeforcesAccount(props) {
         if (Object.prototype.hasOwnProperty.call(data, "JWT Error")) {
             setStatus(data.error);
             setKey("N/A");
-        }
-        else {
+        } else {
             setKey(data["key"]);
         }
     };
 
-    const handleCFLink = async () => {
-        const data = await API.linkCF(potentialHandle, props.JWT).then((response) => response.json());
-        if (Object.prototype.hasOwnProperty.call(data, "Error")) {
-            // linking failed
-            setStatus(data.Error);
-            setStatusIsGood(false);
-        } else {
-            // linking successful, update and display user info
-            setStatus("Handle linked!");
-            setStatusIsGood(true);
-            bootstrap.Modal.getInstance(document.getElementById("cfLinkModal")).hide();
-            setPotentialHandle("");
-            await API.updateUserInfo(props.profileUsername);
-        }
+    const handleCFLink = () => {
+        API.linkCF(potentialHandle, props.JWT).then((response) => response.json());
     };
+
+    // handle response
+    useEffect(() => {
+        if (props.linkResponse) {
+            if (props.linkResponse.status === "OK") {
+                setStatus("Handle linked!");
+                setStatusIsGood(true);
+
+                const modalInstance = bootstrap.Modal.getInstance(document.getElementById("cfLinkModal"));
+                if (modalInstance) {
+                    modalInstance.hide();
+                }
+                setPotentialHandle("");
+                API.updateUserInfo(props.profileUsername);
+            } else {
+                setStatus(props.linkResponse.Error);
+                setStatusIsGood(false);
+            }
+        }
+    }, [props.linkResponse]);
 
     return (
         <>

--- a/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
+++ b/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
@@ -13,6 +13,7 @@ function LinkCodeforcesAccount(props) {
     const [statusIsGood, setStatusIsGood] = useState(true); // determines the color of the status
     const [potentialHandle, setPotentialHandle] = useState("");
     const [key, setKey] = useState("");
+    const [isLinking, setIsLinking] = useState(false); // linking visual
 
     const genKey = async () => {
         const data = await API.getCFLinkKey(props.JWT).then((response) => response.json());
@@ -25,12 +26,14 @@ function LinkCodeforcesAccount(props) {
     };
 
     const handleCFLink = () => {
+        setIsLinking(true);
         API.linkCF(potentialHandle, props.JWT).then((response) => response.json());
     };
 
     // handle response
     useEffect(() => {
         if (props.linkResponse) {
+            setIsLinking(false);
             if (props.linkResponse.status === "OK") {
                 setStatus("Handle linked!");
                 setStatusIsGood(true);
@@ -103,6 +106,11 @@ function LinkCodeforcesAccount(props) {
                             )}
                         </div>
                         <div className="modal-footer">
+                            {
+                                isLinking ? 
+                                <div className="spinner-border spinner-border-sm" role="status"/> :
+                                <></>
+                            }
                             <button type="button" className="btn btn-outline-dark" onClick={handleCFLink}>
                                 Link Account
                             </button>

--- a/client/src/pages/ProfilePage/components/SuggestedProblemCard/components/SuggestedProblem.jsx
+++ b/client/src/pages/ProfilePage/components/SuggestedProblemCard/components/SuggestedProblem.jsx
@@ -15,7 +15,7 @@ function SuggestedProblem(props) {
     const [tags, setTags] = useState([]);
 
     const handleChangeProblemClick = async () => {
-        const data = API.generatedSuggestedProblem(
+        const data = await API.generatedSuggestedProblem(
             props.JWT,
             ratingStart === "" ? -1 : ratingStart,
             ratingEnd === "" ? -1 : ratingEnd,

--- a/server/core/data.js
+++ b/server/core/data.js
@@ -194,56 +194,69 @@ class Data {
         return estimatedRating;
     }
 
-    static async generateSuggestedProblem(username, ratingStart, ratingEnd, tagsChosen) {
-        const metadata = await prisma.Metadata.findUnique({
-            where: { key: "meta" },
-        });
+    static async generateSuggestedProblem(username, ratingStartRaw, ratingEndRaw, tagsChosen) {
+        try {
+            const metadata = await prisma.Metadata.findUnique({
+                where: { key: "meta" },
+            });
 
-        const userInfo = await prisma.User.findUnique({
-            where: { username },
-        });
+            const userInfo = await prisma.User.findUnique({
+                where: { username },
+            });
 
-        const problemsProbabilityOnRatingRange = this.getProblemsProbabilityOnRatingRange(metadata, ratingStart, ratingEnd, tagsChosen);
-        const problemsProbabilityOnUserDifficulty = this.getProblemsProbabilityOnUserDifficulty(userInfo, tagsChosen);
+            // convert ratings so that they are divisible by 100
+            const ratingStart =
+                ratingStartRaw === -1 ? Math.floor(userInfo.estimatedRating / 100) * 100 : Math.ceil(ratingStartRaw / 100) * 100;
 
-        const problemsProbability = problemsProbabilityOnRatingRange;
+            const ratingEnd = ratingEndRaw === -1 ? ratingStart + 300 : Math.floor(ratingEndRaw / 100) * 100;
 
-        for (const tag of Object.keys(problemsProbabilityOnUserDifficulty)) {
-            if (!problemsProbability[tag]) {
-                problemsProbability[tag] = 0;
+            const problemsProbabilityOnRatingRange = this.getProblemsProbabilityOnRatingRange(metadata, ratingStart, ratingEnd, tagsChosen);
+            const problemsProbabilityOnUserDifficulty = this.getProblemsProbabilityOnUserDifficulty(userInfo, tagsChosen);
+
+            const problemsProbability = problemsProbabilityOnRatingRange;
+
+            for (const tag of Object.keys(problemsProbabilityOnUserDifficulty)) {
+                if (!problemsProbability[tag]) {
+                    problemsProbability[tag] = 0;
+                }
+                problemsProbability[tag] += problemsProbabilityOnUserDifficulty[tag];
             }
-            problemsProbability[tag] += problemsProbabilityOnUserDifficulty[tag];
-        }
 
-        for (const tag of Object.keys(problemsProbability)) {
-            problemsProbability[tag] /= 2;
-        }
-
-        // pick a random tag based on their weighted probabilities
-        const randomNum = Math.random();
-        let prefix = 0;
-        let tagChosen = "";
-        for (const tag of Object.keys(problemsProbability)) {
-            prefix += problemsProbability[tag];
-            if (prefix >= randomNum) {
-                tagChosen = tag;
-                break;
+            for (const tag of Object.keys(problemsProbability)) {
+                problemsProbability[tag] /= 2;
             }
+
+            // pick a random tag based on their weighted probabilities
+            const randomNum = Math.random();
+            let prefix = 0;
+            let tagChosen = "";
+            for (const tag of Object.keys(problemsProbability)) {
+                prefix += problemsProbability[tag];
+                if (prefix >= randomNum) {
+                    tagChosen = tag;
+                    break;
+                }
+            }
+
+            const possibleProblems = await prisma.Problem.findMany({
+                where: {
+                    rating: {
+                        gte: ratingStart,
+                        lte: ratingEnd,
+                    },
+                    tags: {
+                        has: tagChosen,
+                    },
+                },
+            });
+
+            await prisma.User.update({
+                where: { username },
+                data: { assignedProblemId: possibleProblems[Math.floor(Math.random() * possibleProblems.length)].id },
+            });
+        } catch (error) {
+            return error;
         }
-
-        const possibleProblems = await prisma.Problem.findMany({
-            where: {
-                rating: {
-                    gte: ratingStart,
-                    lte: ratingEnd,
-                },
-                tags: {
-                    has: tagChosen,
-                },
-            },
-        });
-
-        return possibleProblems[Math.floor(Math.random() * possibleProblems.length)];
     }
 
     static getProblemsProbabilityOnRatingRange(metadata, ratingStart, ratingEnd, tagsChosen) {

--- a/server/core/jobs.js
+++ b/server/core/jobs.js
@@ -40,7 +40,11 @@ const cfWorker = new Worker(
     }
 );
 
-// CF Worker jobs. Any job that uses CF API should be executed through cfWorker due to API limit
+/*
+CF Worker jobs. 
+Any job that uses CF API should be executed through cfWorker due to API limit
+*/
+
 const linkCF = async (username, handle) => {
     // Error handling: is username already linked
     const potentialUserHasHandle = await prisma.User.findUnique({

--- a/server/core/sse.js
+++ b/server/core/sse.js
@@ -1,9 +1,9 @@
 const SSE = {
     userConnections: {},
-    sendUsernameUpdate(username) {
+    sendUsernameUpdate(username, message) {
         if (Object.prototype.hasOwnProperty.call(this.userConnections, username)) {
             for (const client of this.userConnections[username]) {
-                client.write("data: " + JSON.stringify({ message: "UPDATED" }) + "\n\n");
+                client.write("data: " + JSON.stringify(message) + "\n\n");
             }
         }
     },

--- a/server/core/sse.js
+++ b/server/core/sse.js
@@ -16,19 +16,6 @@ const SSE = {
     removeUserClient(username, client) {
         this.userConnections[username] = this.userConnections[username].filter((conn) => conn !== client);
     },
-
-    problemsConnections: [],
-    sendProblemsUpdate() {
-        for (const client of this.problemsConnections) {
-            client.write("data: " + JSON.stringify({ message: "UPDATED" }) + "\n\n");
-        }
-    },
-    addProblemsClient(client) {
-        this.problemsConnections.push(client);
-    },
-    removeProblemsClient(client) {
-        this.problemsConnection = this.problemsConnection.filter(conn => conn !== client);
-    }
 };
 
 module.exports = SSE;

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -95,55 +95,21 @@ router.get("/keygen", authenticateJWT, async (req, res) => {
 });
 
 router.post("/linkCF", authenticateJWT, async (req, res) => {
-    // check if user is already linked
-    const potentialUserHasHandle = await prisma.User.findUnique({
-        where: { username: req.user.username },
-    });
-    if (potentialUserHasHandle.handle !== null) {
-        return res.status(403).json({ Error: "User already linked to a handle. Refresh the page." });
-    }
-    // check if handle is already linked
-    const potentialUserWithHandle = await prisma.User.findUnique({
-        where: { handle: req.body.handle },
-    });
-    if (potentialUserWithHandle !== null) {
-        return res.status(403).json({ Error: "Handle already linked" });
-    }
-
-    let data = {};
-    try {
-        data = await CodeforcesAPI.fetchUserInfo(req.body.handle);
-        if (data.status === "FAILED") {
-            return res.status(403).json({ Error: "No user with handle found" });
-        }
-    } catch (error) {
-        return res.status(403).json({ Error: "Fetch error" });
-    }
-
-    const userToLink = await prisma.User.findUnique({
-        where: { username: req.user.username },
-    });
-    if (userToLink.cfLinkKey != data.result[0].firstName) {
-        return res.status(403).json({ Error: "First name does not match key" });
-    }
-
-    // good match, remove link key and update handle
-    await prisma.User.update({
-        where: { username: req.user.username },
-        data: {
-            handle: req.body.handle,
-            cfLinkKey: "",
-            rating: data.result[0].rating || 0,
-            estimatedRating: data.result[0].rating || 0,
-        },
-    });
-
-    SSE.sendUsernameUpdate(req.user.username);
+    // requires CF, needs to be in a queue
+    cfQueue.add("link user", { fn: "LINK_USER", username: req.user.username, handle: req.body.handle }, { priority: 3 });
     return res.status(200).json({ status: "OK" });
 });
 
 router.post("/updateInfo", async (req, res) => {
+    // requires CF, needs to be in a queue
     try {
+        // inform user that data is updating
+        await prisma.User.update({
+            where: { username: req.body.username },
+            data: { isUpdating: true },
+        });
+        SSE.sendUsernameUpdate(req.body.username, { job: "UPDATE_USER", status: "OK" });
+
         cfQueue.add("update user", { fn: "UPDATE_USER", username: req.body.username }, { priority: 2 });
         return res.status(200).json({ status: "OK" });
     } catch (error) {
@@ -154,8 +120,8 @@ router.post("/updateInfo", async (req, res) => {
 
 router.post("/updateDifficultyRating", authenticateJWT, async (req, res) => {
     try {
-        Data.updateUserRatingDifficulty(req.user.username, req.body.problemId, req.body.newDifficultyRating);
-        SSE.sendUsernameUpdate(req.user.username);
+        await Data.updateUserRatingDifficulty(req.user.username, req.body.problemId, req.body.newDifficultyRating);
+        SSE.sendUsernameUpdate(req.user.username, { job: "UPDATE_USER", status: "OK" });
         return res.status(200).json({ status: "OK" });
     } catch (error) {
         console.error("[Error updating difficulty rating]: ", error);
@@ -165,26 +131,8 @@ router.post("/updateDifficultyRating", authenticateJWT, async (req, res) => {
 
 router.post("/generateSuggestedProblem", authenticateJWT, async (req, res) => {
     try {
-        const oldUserInfo = await prisma.User.findUnique({
-            where: { username: req.user.username },
-        });
-
-        const ratingStart =
-            req.body.ratingStart === -1
-                ? Math.floor(oldUserInfo.estimatedRating / 100) * 100
-                : Math.floor(req.body.ratingStart / 100) * 100;
-
-        const ratingEnd = req.body.ratingEnd === -1 ? ratingStart + 300 : Math.floor(req.body.ratingEnd / 100) * 100;
-
-        const problem = await Data.generateSuggestedProblem(req.user.username, ratingStart, ratingEnd, req.body.tags || []);
-
-        await prisma.User.update({
-            where: { username: req.user.username },
-            data: { assignedProblemId: problem ? problem.id : null },
-            include: USER_INCLUDES,
-        });
-
-        SSE.sendUsernameUpdate(req.user.username);
+        await Data.generateSuggestedProblem(req.user.username, req.body.ratingStart, req.body.ratingEnd, req.body.tags || []);
+        SSE.sendUsernameUpdate(req.user.username, { job: "UPDATE_USER", status: "OK" });
         return res.status(200).json({ status: "OK" });
     } catch (error) {
         console.error(error);
@@ -203,17 +151,6 @@ router.get("/sse/:username", (req, res) => {
         SSE.removeUserClient(username, res);
         res.end();
     });
-});
-
-// TESTING STUFF (IGNORE)
-router.get("/test", async (req, res) => {
-    await Data.updateProblemsData();
-    return res.json({});
-});
-
-router.get("/test2", async (req, res) => {
-    Data.updateUserData("Eric-exe");
-    return res.json({});
 });
 
 module.exports = router;


### PR DESCRIPTION
Description
- Finished changing API calls to Server-sent events (SSEs). Previously, API calls would send data back as soon as they finished processing. However, due to Codeforces API rate limit, it can take a while before data is sent back. To keep the user informed, even if their API is still processing when they refresh the page, SSEs are implemented to send a "finished" response.
- Changed the UI to accomodate the API change.
- Moved more logic from server/routes/userRoutes.js to server/core/data.js and server/core/jobs.js where applicable.

Milestones
- Finished job schedulers so the program continuously fetches fresh data without going past the API rate limit.
- [STRETCH] Finished profile refresh - Because the API was changed to SSEs, implementing the profile refresh only took a line of code.

Resources
- https://medium.com/@techsuneel99/message-queue-in-node-js-with-bullmq-and-redis-7fe5b8a21475 - Setting up BullMQ
- https://ably.com/topic/server-sent-events - Explains SSEs vs web sockets.
- https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events - SSE docs.

Test Plan
- https://www.loom.com/share/82784e667a91457b90d2f095e0a9b4e6. 
  - Notice in the video that data is updated in realtime between profile pages. A user updating their profile page will immediately show an update for another viewer that is not the user.
- The picture below is whats actually being sent to the frontend. After an update notification, the frontend specifically requests user info from the backend.
![image](https://github.com/user-attachments/assets/6a017629-8caa-4f99-afa0-925895a65f1a)

