### PR TITLE
Fix bug where old data isn't updating

### DIFF
--- a/server/core/data.js
+++ b/server/core/data.js
@@ -10,99 +10,136 @@ class Data {
     // should not be used unless called from a job with rate limit
     static async updateUserData(username) {
         await CodeforcesAPI.fetchUserData(username);
-        // count problems AC'ed
-        const totalProblemsAC = await prisma.UserProblemStatus.count({
-            where: {
-                username,
-                AC: { gt: 0 },
-            },
-        });
 
-        // count submission + AC for AC rate, and avg for average rating of problem solved
-        const totalSubmissionsAndAC = await prisma.UserProblemStatus.aggregate({
-            where: { username },
-            _sum: {
-                submissions: true,
-                AC: true,
-            },
-        });
+        try {
+            await prisma.UserProblemStatus.deleteMany({
+                where: { username },
+            });
 
-        const problemStatuses = await prisma.UserProblemStatus.findMany({
-            where: { username },
-            include: {
-                problem: { include: { submissions: { orderBy: { timeCreated: "asc" } } } },
-            },
-        });
+            const submissions = await prisma.Submission.findMany({
+                where: { authorUsername: username },
+                orderBy: { id: "desc" },
+            });
 
-        // count the frequency of a question tag and tag difficulty
-        const tagsFrequency = {};
-        const tagsDifficulty = {};
-        for (const problemStatus of problemStatuses) {
-            // calculate the difficulty of this problem if user didn't submit
-            // based on submissions before AC (not accurate but gets the job done)
-            let userDifficultyRating = problemStatus.userDifficultyRating;
-            if (userDifficultyRating == -1) {
-                let submissionsBeforeAC = 0;
-                let ACed = false;
-                for (const submission of problemStatus.problem.submissions) {
-                    if (submission.verdict === "OK") {
-                        ACed = true;
-                        break;
-                    }
-                    submissionsBeforeAC++;
-                }
-                userDifficultyRating = ACed ? Math.min(1 + submissionsBeforeAC, 5) : 5;
-                await prisma.UserProblemStatus.update({
-                    where: { username_problemId: { username, problemId: problemStatus.problemId } },
-                    data: { userDifficultyRating },
+            for (const submission of submissions) {
+                await prisma.UserProblemStatus.upsert({
+                    where: {
+                        username_problemId: { username, problemId: submission.problemId },
+                    },
+                    create: {
+                        user: { connect: { username } },
+                        problem: { connect: { id: submission.problemId } },
+                        lastAttempted: new Date(submission.timeCreated).toISOString(),
+                        submissions: 1,
+                        AC: submission.verdict === "OK" ? 1 : 0,
+                    },
+                    update: {
+                        submissions: { increment: 1 },
+                        AC: { increment: submission.verdict === "OK" ? 1 : 0 },
+                    },
                 });
             }
-
-            for (const tag of problemStatus.problem.tags) {
-                if (!tagsFrequency[tag]) {
-                    tagsFrequency[tag] = 0;
-                }
-                tagsFrequency[tag]++;
-                if (!tagsDifficulty[tag]) {
-                    tagsDifficulty[tag] = 0;
-                }
-                tagsDifficulty[tag] += userDifficultyRating;
-            }
+        } catch (error) {
+            console.error("[Error updating user problem status]: ", error);
         }
 
-        // count the number of submissions and AC over the last 60 days
-        const past60DaySubmissions = Array(60).fill(0),
-            past60DayAC = Array(60).fill(0);
-        const sortedSubmissions = await prisma.Submission.findMany({
-            where: {
-                authorUsername: username,
-                timeCreated: { gte: new Date(new Date().setDate(new Date().getDate() - 60)) },
-            },
-            orderBy: { timeCreated: "desc" },
-        });
+        try {
+            // count problems AC'ed
+            const totalProblemsAC = await prisma.UserProblemStatus.count({
+                where: {
+                    username,
+                    AC: { gt: 0 },
+                },
+            });
 
-        const timeNow = new Date();
-        for (const submission of sortedSubmissions) {
-            const dayDiff = Math.floor((timeNow - new Date(submission.timeCreated)) / (1000 * 60 * 60 * 24));
-            past60DaySubmissions[dayDiff]++;
-            if (submission.verdict === "OK") {
-                past60DayAC[dayDiff]++;
+            // count submission + AC for AC rate, and avg for average rating of problem solved
+            const totalSubmissionsAndAC = await prisma.UserProblemStatus.aggregate({
+                where: { username },
+                _sum: {
+                    submissions: true,
+                    AC: true,
+                },
+            });
+
+            const problemStatuses = await prisma.UserProblemStatus.findMany({
+                where: { username },
+                include: {
+                    problem: { include: { submissions: { orderBy: { timeCreated: "asc" } } } },
+                },
+            });
+
+            // count the frequency of a question tag and tag difficulty
+            const tagsFrequency = {};
+            const tagsDifficulty = {};
+            for (const problemStatus of problemStatuses) {
+                // calculate the difficulty of this problem if user didn't submit
+                // based on submissions before AC (not accurate but gets the job done)
+                let userDifficultyRating = problemStatus.userDifficultyRating;
+                if (userDifficultyRating == -1) {
+                    let submissionsBeforeAC = 0;
+                    let ACed = false;
+                    for (const submission of problemStatus.problem.submissions) {
+                        if (submission.verdict === "OK") {
+                            ACed = true;
+                            break;
+                        }
+                        submissionsBeforeAC++;
+                    }
+                    userDifficultyRating = ACed ? Math.min(1 + submissionsBeforeAC, 5) : 5;
+                    await prisma.UserProblemStatus.update({
+                        where: { username_problemId: { username, problemId: problemStatus.problemId } },
+                        data: { userDifficultyRating },
+                    });
+                }
+
+                for (const tag of problemStatus.problem.tags) {
+                    if (!tagsFrequency[tag]) {
+                        tagsFrequency[tag] = 0;
+                    }
+                    tagsFrequency[tag]++;
+                    if (!tagsDifficulty[tag]) {
+                        tagsDifficulty[tag] = 0;
+                    }
+                    tagsDifficulty[tag] += userDifficultyRating;
+                }
             }
-        }
 
-        await prisma.User.update({
-            where: { username },
-            data: {
-                problemsAC: totalProblemsAC,
-                totalSubmissions: totalSubmissionsAndAC._sum.submissions,
-                totalAC: totalSubmissionsAndAC._sum.AC,
-                tagsFrequency,
-                tagsDifficulty,
-                recentSubmissions: past60DaySubmissions,
-                recentAC: past60DayAC,
-                lastUpdated: new Date().toISOString(),
-            },
-        });
+            // count the number of submissions and AC over the last 60 days
+            const past60DaySubmissions = Array(60).fill(0),
+                past60DayAC = Array(60).fill(0);
+            const sortedSubmissions = await prisma.Submission.findMany({
+                where: {
+                    authorUsername: username,
+                    timeCreated: { gte: new Date(new Date().setDate(new Date().getDate() - 60)) },
+                },
+                orderBy: { timeCreated: "desc" },
+            });
+
+            const timeNow = new Date();
+            for (const submission of sortedSubmissions) {
+                const dayDiff = Math.floor((timeNow - new Date(submission.timeCreated)) / (1000 * 60 * 60 * 24));
+                past60DaySubmissions[dayDiff]++;
+                if (submission.verdict === "OK") {
+                    past60DayAC[dayDiff]++;
+                }
+            }
+
+            await prisma.User.update({
+                where: { username },
+                data: {
+                    problemsAC: totalProblemsAC,
+                    totalSubmissions: totalSubmissionsAndAC._sum.submissions,
+                    totalAC: totalSubmissionsAndAC._sum.AC,
+                    tagsFrequency,
+                    tagsDifficulty,
+                    recentSubmissions: past60DaySubmissions,
+                    recentAC: past60DayAC,
+                    lastUpdated: new Date().toISOString(),
+                },
+            });
+        } catch (error) {
+            console.error("[Error updating user stats]: ", error);
+        }
     }
 
     // should not be used unless called from a job with rate limit


### PR DESCRIPTION
TLDR:
- Bug causes old data to not update when the API data updates.
- Resolution: Update every single data instead of terminating early.

Description
Codeforces hosts contests in a way such that the system has pre-tests and assigns a pre-test AC to the user. Afterwards, during system tests, the user gets their actual AC or WA if they failed/got hacked (malicious input by another user). 

Problems rating from recent contests do not come out instantly but take a bit. 

The bug:
The backend assumes that the data is constant and will terminate updating user submissions or problem data if the submission or problem exists in the database. It never updates a previously written entry which causes old problems/submissions data not to be updated.

In this pull request, the bug fix is to update every submissions & problems data instead of terminating early.

Also, as updating submissions is closer to data.js instead of CodeforcesAPI.js, I moved the submissions data over. Now, Codeforces API should only be responsible for fetching data and writing immediate data to Prisma (previously, it processed some metadata for user submissions (userProblemStatus).