### PR TITLE
Resources tab vote implementation

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -61,6 +61,10 @@ class API {
     static createPost(JWT, title, body, tags) {
         return this.fetchRequest(import.meta.env.VITE_DB_URL + "/posts/create", "POST", JSON.stringify({ title, body, tags }), JWT);
     }
+
+    static updatePostVotes(JWT, id, voteType) {
+        return this.fetchRequest(import.meta.env.VITE_DB_URL + "/posts/vote", "POST", JSON.stringify({ id, voteType }), JWT);
+    }
 }
 
 export default API;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -34,3 +34,12 @@ a {
 .ag-theme-alpine .ag-row-even {
   background-color: rgb(0, 0, 0, 0.05); 
 }
+
+.hover-pop {
+  transition: all 0.2s;
+}
+
+.hover-pop:hover {
+  transform: scale(1.2);
+  cursor: pointer;
+}

--- a/client/src/pages/ResourcesPage/ResourcesBar.jsx
+++ b/client/src/pages/ResourcesPage/ResourcesBar.jsx
@@ -44,7 +44,7 @@ function ResourcesBar(props) {
     useEffect(() => {
         const debounceFn = debounce(() => {
             getPosts();
-        }, 500);
+        }, 300);
         debounceFn();
     }, [title, tags, sortBy]);
 

--- a/client/src/pages/ResourcesPage/ResourcesPage.jsx
+++ b/client/src/pages/ResourcesPage/ResourcesPage.jsx
@@ -25,7 +25,7 @@ function ResourcesPage(props) {
             <div className="card card-body m-4 shadow">
                 <div className="accordion accordion-flush" id="posts-accordion">
                     {postsData.map((data, index) => (
-                        <Post key={index} data={data} />
+                        <Post key={index} userInfo={props.userInfo} data={data} JWT={props.JWT} JWTSetter={props.JWTSetter}/>
                     ))}
                 </div>
             </div>

--- a/server/routes/postsRoutes.js
+++ b/server/routes/postsRoutes.js
@@ -72,7 +72,6 @@ Response:
 */
 router.post("/vote", authenticateJWT, async (req, res) => {
     try {
-        // remove old vote if it exists
         const post = await prisma.Post.findUnique({
             where: { id: req.body.id },
             include: {
@@ -85,13 +84,13 @@ router.post("/vote", authenticateJWT, async (req, res) => {
         let disconnectField = null;
         let connectField = null;
 
-        const oldVote = post.upvotes.some(user => user.username === req.user.username) ? 'upvotes' :
-                        post.downvotes.some(user => user.username === req.user.username) ? 'downvotes' : 
+        const oldVote = post.upvotes.some(user => user.username === req.user.username) ? "upvotes" :
+                        post.downvotes.some(user => user.username === req.user.username) ? "downvotes" : 
                         null;
 
         if (oldVote !== null) {
             disconnectField = oldVote;
-            voteDelta += (oldVote === 'upvotes' ? -1 : 1);
+            voteDelta += (oldVote === "upvotes" ? -1 : 1);
         }
 
         const newVote = req.body.voteType === "neutral" ? null : 

--- a/server/routes/postsRoutes.js
+++ b/server/routes/postsRoutes.js
@@ -54,4 +54,76 @@ router.post("/create", authenticateJWT, async (req, res) => {
     }
 });
 
+/*
+Updates the upvotes in a post after someone has upvoted by disconnecting user from their old vote in db and 
+connect them to their new vote (if not neutral), and updates votes (# of upvotes - # of downvotes) to reflect that.
+
+Note: neutral voteType occurs when the user uses the same vote twice, effectively removing their vote.
+
+REQUIRES the JWT in auth header.
+Request Body: 
+{
+    id: post id
+    voteType: one of "upvote", "neutral", "downvote"
+}
+
+Response:
+{ status: OK } if it succeeds
+*/
+router.post("/vote", authenticateJWT, async (req, res) => {
+    try {
+        // remove old vote if it exists
+        const post = await prisma.Post.findUnique({
+            where: { id: req.body.id },
+            include: {
+                upvotes: true,
+                downvotes: true
+            }
+        });
+
+        let voteDelta = 0;
+        let disconnectField = null;
+        let connectField = null;
+
+        const oldVote = post.upvotes.some(user => user.username === req.user.username) ? 'upvotes' :
+                        post.downvotes.some(user => user.username === req.user.username) ? 'downvotes' : 
+                        null;
+
+        if (oldVote !== null) {
+            disconnectField = oldVote;
+            voteDelta += (oldVote === 'upvotes' ? -1 : 1);
+        }
+
+        const newVote = req.body.voteType === "neutral" ? null : 
+                        req.body.voteType == "upvote" ? "upvotes" : "downvotes";
+        
+        if (newVote !== null) {
+            connectField = newVote;
+            voteDelta += (newVote == "upvotes" ? 1 : -1);
+        }
+
+        await prisma.Post.update({
+            where: { id: req.body.id },
+            data: {
+                ...(disconnectField !== null && { 
+                    [disconnectField]: {
+                        disconnect: [{ username: req.user.username }]
+                    }
+                }),
+                ...(connectField !== null && {
+                    [connectField]: {
+                        connect: [{ username: req.user.username }]
+                    }
+                }),
+                votes: post.votes + voteDelta,
+            }
+        });
+
+        return res.status(200).json({ status: "OK" });
+    } catch (error) {
+        console.error("[Vote post error]: ", error);
+        return res.status(409).json({ status: "FAILED" });
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Description
This pull request implements the upvote & downvotes into the resources board. Specifically, users can either upvote or downvote a post but they cannot upvote/downvote more than once. Because the sorting defaults to upvotes descending, more popular posts will be higher up in the board, and thus, more likely to be seen.

Also, users not logged in cannot vote.

## Milestones
- [x] Resources board -> implement users being able to upvote/downvote posts.

## Resources
- https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries: For connections (connect/disconnect) in Prisma DB.

## Test Plan
https://www.loom.com/share/8911d09da46344a89b60c94206ef709c
Notice that the vote score changes by more than 1 if the user changes their votes from upvote to downvote or vice versa. This is intentional and is similar to that of reddit.

