### PR TITLE
Main Tab Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### Week 8
 - [x] Finish the resources board if necessary
-- [ ] Implement general page, listing upcoming and previous contests.
+- [x] Implement general page, listing upcoming and previous contests.
 - [ ] STRETCH: Visualize user stats with graphs via a graph library
 - [x] Add refresh button to profile, fetching latest data. Has to work with task schedulers as to not spam Codeforces API
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -48,7 +48,7 @@ function App() {
             <Router>
                 <NavBar userInfo={userInfo} />
                 <Routes>
-                    <Route index element={<HomePage />} />
+                    <Route index element={<HomePage userInfo={userInfo}/>} />
                     <Route path="problems" element={<ProblemsPage userInfo={userInfo} />} />
                     <Route path="resources" element={<ResourcesPage userInfo={userInfo} JWT={JWT} JWTSetter={setJWT} />} />
                     <Route

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,7 +35,7 @@ function App() {
                 setUserInfo(data);
             }
         };
-        
+
         if (JWT !== "") {
             updateUserInfo();
         } else {
@@ -43,12 +43,37 @@ function App() {
         }
     }, [JWT]);
 
+    const [upcomingContestsData, setUpcomingContestsData] = useState([]);
+    const [pastContestsData, setPastContestsData] = useState([]);
+
+    // load data on init
+    useEffect(() => {
+        const fetchPublicData = async () => {
+            const response = await API.getContestsData().then((response) => response.json());
+            if (response.status === "OK") {
+                setUpcomingContestsData(response.upcomingContests);
+                setPastContestsData(response.pastContests);
+            }
+        };
+
+        fetchPublicData();
+    }, []);
+
+    useEffect(() => {
+        console.log(upcomingContestsData);
+    }, [upcomingContestsData]);
+
     return (
         <>
             <Router>
                 <NavBar userInfo={userInfo} />
                 <Routes>
-                    <Route index element={<HomePage userInfo={userInfo}/>} />
+                    <Route
+                        index
+                        element={
+                            <HomePage userInfo={userInfo} upcomingContestsData={upcomingContestsData} pastContestsData={pastContestsData} />
+                        }
+                    />
                     <Route path="problems" element={<ProblemsPage userInfo={userInfo} />} />
                     <Route path="resources" element={<ResourcesPage userInfo={userInfo} JWT={JWT} JWTSetter={setJWT} />} />
                     <Route

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -73,6 +73,10 @@ class API {
     static deletePost(JWT, id) {
         return this.fetchRequest(import.meta.env.VITE_DB_URL + "/posts/delete", "POST", JSON.stringify({ id }), JWT);
     }
+
+    static getContestsData() {
+        return this.fetchRequest(import.meta.env.VITE_DB_URL + "/contests/data", "GET", "", "");
+    }
 }
 
 export default API;

--- a/client/src/components/ContestLinkRenderer.jsx
+++ b/client/src/components/ContestLinkRenderer.jsx
@@ -1,0 +1,15 @@
+import propTypes from "prop-types";
+
+ContestLinkRenderer.propTypes = {
+    data: propTypes.object.isRequired,
+}
+
+function ContestLinkRenderer(params) {
+    return (
+        <a href={`https://codeforces.com/contest/${params.data.id}`}>
+            {params.data.name}
+        </a>
+    );
+}
+
+export default ContestLinkRenderer;

--- a/client/src/pages/HomePage/Contests.jsx
+++ b/client/src/pages/HomePage/Contests.jsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { AgGridReact } from "ag-grid-react";
+import ContestLinkRenderer from "../../components/ContestLinkRenderer";
+import propTypes from "prop-types";
+
+Contests.propTypes = {
+    title: propTypes.string.isRequired,
+    data: propTypes.array.isRequired,
+    height: propTypes.string.isRequired,
+};
+
+function Contests(props) {
+    const weekday = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
+
+    const columnDefs = [
+        { field: "id", headerName: "ID", sortable: false, filter: false },
+        { field: "name", headerName: "Contest Name", sortable: false, filter: false, flex: 2, cellRenderer: ContestLinkRenderer },
+        { field: "startTime", headerName: "Start", sortable: false, filter: false, flex: 1 },
+        { field: "durationMins", headerName: "Duration (minutes)", sortable: false, filter: false },
+    ];
+
+    const [rowData, setRowData] = useState([]);
+
+    useEffect(() => {
+        const rows = props.data.map((contest) => ({
+            id: contest.id,
+            name: contest.name,
+            startTime: `${new Date(contest.startTime).toLocaleString()} (${weekday[new Date(contest.startTime).getDay()]})`,
+            durationMins: contest.durationSeconds / 60
+        }));
+        setRowData(rows);
+    }, [props.data]);
+
+    return (
+        <div className="card m-4 shadow">
+            <div className="card-header">
+                <b>{props.title}</b>
+            </div>
+            <div className="card-body">
+                <div className="body d-flex justify-content-center align-items-center p-2">
+                    <div className="ag-theme-alpine" style={{ height: props.height, width: "100%" }}>
+                        <AgGridReact columnDefs={columnDefs} rowData={rowData}  />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default Contests;

--- a/client/src/pages/HomePage/HomePage.jsx
+++ b/client/src/pages/HomePage/HomePage.jsx
@@ -1,7 +1,10 @@
+import Contests from "./Contests";
 import propTypes from "prop-types";
 
 HomePage.propTypes = {
     userInfo: propTypes.object.isRequired,
+    upcomingContestsData: propTypes.array.isRequired,
+    pastContestsData: propTypes.array.isRequired,
 };
 
 function HomePage(props) {
@@ -10,6 +13,9 @@ function HomePage(props) {
             <div className="card card-body shadow m-4">
                 Hello {props.userInfo.username}!
             </div>
+
+            <Contests title="Upcoming Contests" height="30vh" data={props.upcomingContestsData}/>
+            <Contests title="Previous Contests" height="60vh" data={props.pastContestsData}/>
         </>
     );
 }

--- a/client/src/pages/HomePage/HomePage.jsx
+++ b/client/src/pages/HomePage/HomePage.jsx
@@ -1,6 +1,16 @@
-function HomePage() {
+import propTypes from "prop-types";
+
+HomePage.propTypes = {
+    userInfo: propTypes.object.isRequired,
+};
+
+function HomePage(props) {
     return (
-        <>This is the homepage</>
+        <>
+            <div className="card card-body shadow m-4">
+                Hello {props.userInfo.username}!
+            </div>
+        </>
     );
 }
 

--- a/server/core/CodeforcesAPI.js
+++ b/server/core/CodeforcesAPI.js
@@ -115,9 +115,7 @@ class CodeforcesAPI {
                 throw new Error(`status not ok: ${JSON.stringify(data)}`);
             }
 
-            const contests = data.result;
-
-            for (const contestData of contests) {
+            for (const contestData of data.result) {
                 await prisma.Contest.upsert({
                     where: { id: contestData.id },
                     create: {

--- a/server/core/jobs.js
+++ b/server/core/jobs.js
@@ -10,8 +10,9 @@ const cfQueue = new Queue("codeforces queue", {
     connection: redisConnection,
 });
 
-// update problems at 12 AM
+// update data at 12 AM
 cfQueue.add("update problems", { fn: "UPDATE_PROBLEM" }, { repeat: { cron: "0 0 * * *" }, priority: 1 });
+cfQueue.add("update contests", { fn: "UPDATE_CONTEST" }, { repeat: { cron: "0 0 * * *" }, priority: 1 });
 
 const cfWorker = new Worker(
     "codeforces queue",
@@ -20,6 +21,9 @@ const cfWorker = new Worker(
         switch (job.data.fn) {
             case "UPDATE_PROBLEM":
                 updateProblemsData();
+                break;
+            case "UPDATE_CONTEST":
+                CodeforcesAPI.fetchContestsInfo();
                 break;
             case "UPDATE_USER":
                 updateUserData(job.data.username);

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ app.use("/contests", require("./routes/contestsRoutes"));
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
+const CodeforcesAPI = require("./core/CodeforcesAPI");
 const Data = require("./core/data");
 
 const PORT = 3000;
@@ -26,6 +27,8 @@ app.listen(PORT, async () => {
     });
     console.log("Updating problems data...");
     await Data.updateProblemsData();
+    console.log("Updating contests data...");
+    await CodeforcesAPI.fetchContestsInfo();
 
     console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ app.use(express.json());
 app.use("/user", require("./routes/userRoutes"));
 app.use("/problems", require("./routes/problemsRoutes"));
 app.use("/posts", require("./routes/postsRoutes"));
+app.use("/contests", require("./routes/contestsRoutes"));
 
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -106,7 +106,7 @@ model Contest {
     id                          Int                     @id @unique
     name                        String                  
     type                        String
-    phase                       String
+    phase                       String                  @id
     startTime                   DateTime
-    durationSeconds             Int
+    durationMins                Int
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -101,3 +101,12 @@ model Post {
     @@index([authorUsername])
     @@unique([id, authorUsername])
 }
+
+model Contest {
+    id                          Int                     @id @unique
+    name                        String                  
+    type                        String
+    phase                       String
+    startTime                   DateTime
+    durationSeconds             Int
+}

--- a/server/routes/contestsRoutes.js
+++ b/server/routes/contestsRoutes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const CodeforcesAPI = require("../core/CodeforcesAPI");
+
+router.get("/update", async (req, res) => {
+    CodeforcesAPI.fetchContestsInfo();
+});
+
+module.exports = router;

--- a/server/routes/contestsRoutes.js
+++ b/server/routes/contestsRoutes.js
@@ -1,9 +1,25 @@
 const express = require("express");
 const router = express.Router();
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
 const CodeforcesAPI = require("../core/CodeforcesAPI");
 
 router.get("/update", async (req, res) => {
     CodeforcesAPI.fetchContestsInfo();
+});
+
+router.get("/data", async (req, res) => {
+    const upcomingContests = await prisma.Contest.findMany({
+        where: { phase: "BEFORE" },
+        orderBy: { startTime: "asc" }
+    });
+
+    const pastContests = await prisma.Contest.findMany({
+        where: { phase: "FINISHED" },
+        orderBy: { startTime: "desc" }
+    });
+
+    return res.json({ status: "OK", upcomingContests, pastContests });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Description
This PR implements contest data display for the main page. Specifically, it displays upcoming and past contests with links to said contest. It also displays the date and time in the local timezone, including the what day of the week the contest is hosted in.

## Milestones
- [x] Implement the general page, listing the upcoming and previous contests
## Resources

## Test Plan
<img width="1728" alt="Screenshot 2024-07-22 at 1 30 36 PM" src="https://github.com/user-attachments/assets/5fc4e4bc-3fca-4584-a3a4-c48b2cb6f0c0">