### PR TITLE
Implement a card for problems that are not solved

### DIFF
--- a/client/src/pages/ProfilePage/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage/ProfilePage.jsx
@@ -7,6 +7,7 @@ import SuggestedProblemCard from "./components/SuggestedProblemCard/SuggestedPro
 import ProblemStatsCard from "./components/ProblemStatsCard/ProblemStatsCard";
 import ActivityGraphStatsCard from "./components/ActivityGraphStatsCard/ActivityGraphStatsCard";
 import SubmissionsStatsCard from "./components/SubmissionsStatsCard";
+import RevisionsCard from "./components/RevisionsCard";
 
 ProfilePage.propTypes = {
     userInfo: propTypes.object.isRequired,
@@ -161,7 +162,7 @@ function ProfilePage(props) {
                                         <></>
                                     )}
 
-                                    <ProblemStatsCard profileInfo={profileInfo} metadata={props.metadata}/>
+                                    <ProblemStatsCard profileInfo={profileInfo} metadata={props.metadata} />
 
                                     <div className="m-4">
                                         <div className="row">
@@ -184,6 +185,7 @@ function ProfilePage(props) {
                                     </div>
 
                                     <SubmissionsStatsCard profileInfo={profileInfo} />
+                                    {pageMode === "owner" ? <RevisionsCard userInfo={props.userInfo} /> : <></>}
                                 </>
                             )}
                         </div>

--- a/client/src/pages/ProfilePage/components/RevisionsCard.jsx
+++ b/client/src/pages/ProfilePage/components/RevisionsCard.jsx
@@ -1,0 +1,35 @@
+import { AgGridReact } from "ag-grid-react";
+import propTypes from "prop-types";
+import ProblemLinkRenderer from "../../../components/ProblemLinkRenderer";
+
+RevisionsCard.propTypes = {
+    userInfo: propTypes.object.isRequired,
+};
+
+function RevisionsCard(props) {
+    const columnDefs = [
+        { field: "contestId", headerName: "Contest ID", sortable: true, filter: true },
+        { field: "index", headerName: "Index", sortable: true, filter: true },
+        { field: "name", headerName: "Problem Name", sortable: true, filter: true, cellRenderer: ProblemLinkRenderer, flex: 1 },
+    ];
+
+    return (
+        <div className="card shadow m-4">
+            <div className="card-header" data-bs-toggle="collapse" data-bs-target="#revisions-body" role="button">
+                <b>Revisions</b>
+            </div>
+            <div className="collapse show" id="revisions-body">
+                <div className="container-fluid">
+                    <div className="container-fluid mt-3">
+                        These are the problems that you have failed to solve:
+                        <div className="ag-theme-alpine my-3" style={{ height: "45vh", width: "100%" }}>
+                            <AgGridReact columnDefs={columnDefs} rowData={props.userInfo.unsolvedProblems} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default RevisionsCard;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -30,9 +30,10 @@ model Problem {
     tags                        String[]
 
     // handles relationships, shouldn't be accessed from this field
-    assigned                    User[]
+    assigned                    User[]                  
     userProblems                UserProblemStatus[]
     submissions                 Submission[]
+    UsersUnsolved               User[]                  @relation("UserProblemsUnsolved")
 }
 
 model User {
@@ -53,6 +54,7 @@ model User {
     assignedProblemId           String?
     recentSubmissions           Int[]
     recentAC                    Int[]
+    unsolvedProblems            Problem[]               @relation("UserProblemsUnsolved")
     posts                       Post[]
     postsUpvoted                Post[]                  @relation("upvotedPosts")
     postsDownvoted              Post[]                  @relation("downvotedPosts")

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -19,6 +19,7 @@ const USER_INCLUDES = {
         include: { problem: true },
         orderBy: { timeCreated: "desc" },
     },
+    unsolvedProblems: true,
 };
 
 const KEYGEN_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890";


### PR DESCRIPTION
## Description
This PR implements a card in the profile page that displays the problems the user has attempted but yet to solve. This is a part of the stretch feature that allows users to mark problems for revision, even if they solved it before.

## Milestones
- Implement “couldn’t solve”, storing the questions the user failed to solve in the past

## Resources

## Test Plan
<img width="1728" alt="Screenshot 2024-07-26 at 4 30 50 PM" src="https://github.com/user-attachments/assets/c691a0d8-490d-4358-a156-ce0c00369668">

