### PR TITLE
User Handle Unlink Button

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -85,6 +85,10 @@ class API {
     static markProblemForRevision(JWT, problemId, markToRevise) {
         return this.fetchRequest(import.meta.env.VITE_BACKEND_URL + "/user/markProblemForRevision", "POST", JSON.stringify({ problemId, markToRevise }), JWT);
     }
+
+    static unlinkHandle(JWT) {
+        return this.fetchRequest(import.meta.env.VITE_BACKEND_URL + "/user/unlink", "GET", "", JWT); 
+    }
 }
 
 export default API;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -47,3 +47,19 @@ a {
 .nav-link-color {
   border-color: rgb(255, 255, 255, 0.55) !important;
 }
+
+/* Hover for unlink */
+#profilePageUserHandle #profilePageHandleUnlink {
+  opacity: 0;
+  visibility: hidden;
+  max-height: 0;
+  overflow: hidden;
+  transition: opacity 0.5s, visibility 0s 0.5s, max-height 0.5s;
+}
+
+#profilePageUserHandle:hover #profilePageHandleUnlink {
+  opacity: 1;
+  visibility: visible;
+  max-height: 40px; 
+  transition: opacity 0.5s, visibility 0s, max-height 0.5s;
+}

--- a/client/src/pages/ProfilePage/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage/ProfilePage.jsx
@@ -8,6 +8,7 @@ import ProblemStatsCard from "./components/ProblemStatsCard/ProblemStatsCard";
 import ActivityGraphStatsCard from "./components/ActivityGraphStatsCard/ActivityGraphStatsCard";
 import SubmissionsStatsCard from "./components/SubmissionsStatsCard";
 import RevisionsCard from "./components/RevisionsCard";
+import UnlinkCodeforcesAccount from "./components/UnlinkCodeforcesAccount";
 
 ProfilePage.propTypes = {
     userInfo: propTypes.object.isRequired,
@@ -91,16 +92,26 @@ function ProfilePage(props) {
                             {/* General user stat bar */}
                             <div className="card card-body shadow m-4 overflow-auto">
                                 <div className="row">
-                                    <div className="d-flex col-lg-3 my-auto flex-wrap">
+                                    <div className="d-flex col-xl-3 my-auto flex-wrap text-truncate">
                                         <b>Username:&nbsp;</b>
                                         {profileInfo.username}
                                     </div>
-                                    <div className="d-flex col-lg-3 my-auto flex-wrap">
+                                    <div className="d-flex col-xl-3 my-auto flex-wrap text-truncate">
                                         {/* Display username or link button if it doesn't exist and user is owner */}
                                         <b className="text-nowrap my-auto">Codeforces Handle:&nbsp;</b>
                                         {profileInfo.handle !== null ? (
-                                            <>{profileInfo.handle}</>
-                                        ) : pageMode == "owner" ? (
+                                            <div
+                                                className="d-flex justify-content-between align-items-center flex-grow-1 text-truncate"
+                                                id="profilePageUserHandle"
+                                            >
+                                                <div className="text-truncate">{profileInfo.handle}</div>
+                                                {pageMode === "owner" ? (
+                                                    <UnlinkCodeforcesAccount JWT={props.JWT} JWTSetter={props.JWTSetter} />
+                                                ) : (
+                                                    <></>
+                                                )}
+                                            </div>
+                                        ) : pageMode === "owner" ? (
                                             <LinkCodeforcesAccount
                                                 profileUsername={profileUsername}
                                                 JWT={props.JWT}
@@ -112,13 +123,13 @@ function ProfilePage(props) {
                                             <></>
                                         )}
                                     </div>
-                                    <div className="d-flex col-lg-3 flex-wrap my-auto">
+                                    <div className="d-flex col-xl-3 flex-wrap my-auto">
                                         <b className="text-nowrap">Estimated Rating:&nbsp;</b>
                                         {profileInfo.handle === null
                                             ? ""
                                             : String(profileInfo.estimatedRating) + " (" + String(profileInfo.rating) + ")"}
                                     </div>
-                                    <div className="d-flex col-lg-3 justify-content-between">
+                                    <div className="d-flex col-xl-3 justify-content-between">
                                         <div className="d-flex my-auto flex-wrap">
                                             <b className="text-nowrap">Last updated:&nbsp;</b>
                                             {profileInfo.handle !== null ? (

--- a/client/src/pages/ProfilePage/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage/ProfilePage.jsx
@@ -118,6 +118,7 @@ function ProfilePage(props) {
                                                 userInfoSetter={props.userInfoSetter}
                                                 profileInfoSetter={setProfileInfo}
                                                 linkResponse={linkResponse}
+                                                linkResponseSetter={setLinkResponse}
                                             />
                                         ) : (
                                             <></>

--- a/client/src/pages/ProfilePage/ProfilePage.jsx
+++ b/client/src/pages/ProfilePage/ProfilePage.jsx
@@ -81,6 +81,42 @@ function ProfilePage(props) {
         API.updateUserInfo(profileUsername);
     };
 
+    const renderUnlinkButton = () => {
+        if (pageMode === "owner") {
+            return <UnlinkCodeforcesAccount JWT={props.JWT} JWTSetter={props.JWTSetter} />;
+        }
+        return null;
+    };
+
+    // Function to render the handle or the link/unlink button based on the user's state
+    const renderUserHandleOrLink = () => {
+        const { handle } = profileInfo;
+        // If the user has a handle, show it with unlink button if user is owner
+        if (handle) {
+            return (
+                <div className="d-flex justify-content-between align-items-center flex-grow-1 text-truncate" id="profilePageUserHandle">
+                    <div className="text-truncate">{handle}</div>
+                    {renderUnlinkButton()}
+                </div>
+            );
+        }
+
+        // If no handle and the user is the owner, show the link account component
+        if (pageMode === "owner") {
+            return (
+                <LinkCodeforcesAccount
+                    profileUsername={profileUsername}
+                    JWT={props.JWT}
+                    userInfoSetter={props.userInfoSetter}
+                    profileInfoSetter={setProfileInfo}
+                    linkResponse={linkResponse}
+                    linkResponseSetter={setLinkResponse}
+                />
+            );
+        }
+        return null;
+    };
+
     return (
         <>
             {profileInfo === null ? (
@@ -97,32 +133,8 @@ function ProfilePage(props) {
                                         {profileInfo.username}
                                     </div>
                                     <div className="d-flex col-xl-3 my-auto flex-wrap text-truncate">
-                                        {/* Display username or link button if it doesn't exist and user is owner */}
                                         <b className="text-nowrap my-auto">Codeforces Handle:&nbsp;</b>
-                                        {profileInfo.handle !== null ? (
-                                            <div
-                                                className="d-flex justify-content-between align-items-center flex-grow-1 text-truncate"
-                                                id="profilePageUserHandle"
-                                            >
-                                                <div className="text-truncate">{profileInfo.handle}</div>
-                                                {pageMode === "owner" ? (
-                                                    <UnlinkCodeforcesAccount JWT={props.JWT} JWTSetter={props.JWTSetter} />
-                                                ) : (
-                                                    <></>
-                                                )}
-                                            </div>
-                                        ) : pageMode === "owner" ? (
-                                            <LinkCodeforcesAccount
-                                                profileUsername={profileUsername}
-                                                JWT={props.JWT}
-                                                userInfoSetter={props.userInfoSetter}
-                                                profileInfoSetter={setProfileInfo}
-                                                linkResponse={linkResponse}
-                                                linkResponseSetter={setLinkResponse}
-                                            />
-                                        ) : (
-                                            <></>
-                                        )}
+                                        {renderUserHandleOrLink()}
                                     </div>
                                     <div className="d-flex col-xl-3 flex-wrap my-auto">
                                         <b className="text-nowrap">Estimated Rating:&nbsp;</b>

--- a/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
+++ b/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
@@ -35,13 +35,11 @@ function LinkCodeforcesAccount(props) {
         if (props.linkResponse) {
             setIsLinking(false);
             if (props.linkResponse.status === "OK") {
-                setStatus("Handle linked!");
-                setStatusIsGood(true);
-
                 const modalInstance = bootstrap.Modal.getInstance(document.getElementById("cfLinkModal"));
                 if (modalInstance) {
                     modalInstance.hide();
                 }
+                setStatus("");
                 setPotentialHandle("");
                 API.updateUserInfo(props.profileUsername);
             } else {

--- a/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
+++ b/client/src/pages/ProfilePage/components/LinkCodeforcesAccount.jsx
@@ -6,6 +6,7 @@ LinkCodeforcesAccount.propTypes = {
     profileUsername: propTypes.string.isRequired,
     JWT: propTypes.string.isRequired,
     linkResponse: propTypes.object.isRequired,
+    linkResponseSetter: propTypes.func.isRequired, 
 };
 
 function LinkCodeforcesAccount(props) {
@@ -48,6 +49,14 @@ function LinkCodeforcesAccount(props) {
             }
         }
     }, [props.linkResponse]);
+
+
+    // handle unmount
+    useEffect(() => {
+        return () => {
+            props.linkResponseSetter({});
+        };
+    }, []);
 
     return (
         <>

--- a/client/src/pages/ProfilePage/components/SubmissionsStatsCard.jsx
+++ b/client/src/pages/ProfilePage/components/SubmissionsStatsCard.jsx
@@ -24,7 +24,7 @@ function SubmissionsStatsCard(props) {
         { field: "verdict", headerName: "Status", sortable: true, filter: true },
         { field: "time", headerName: "Submission Time", sortable: false },
         { field: "programmingLang", headerName: "Programming Language", sortable: false },
-        { field: "timeUsed", headername: "Time (ms)", sortable: false },
+        { field: "timeUsed", headerName: "Time (ms)", sortable: false },
         { field: "memoryUsed", headerName: "Memory (kb)", sortable: false },
     ];
 

--- a/client/src/pages/ProfilePage/components/SuggestedProblemCard/RecentProblemsRater.jsx
+++ b/client/src/pages/ProfilePage/components/SuggestedProblemCard/RecentProblemsRater.jsx
@@ -49,7 +49,7 @@ function RecentProblemsRater(props) {
 
     const ReviseButtonRenderer = (params) => {
         if (params.data.markedForRevision || params.data.AC === 0) {
-            return <>In Revisions</>;
+            return <div className="d-flex justify-content-center align-items-center">In Revisions</div>;
         }
         return (
             <div className="d-flex h-100 justify-content-center align-items-center">
@@ -107,7 +107,7 @@ function RecentProblemsRater(props) {
 
     const responseHandler = async (fn) => {
         try {
-            const response = await fn().then(response => response.json());
+            const response = await fn().then((response) => response.json());
             if (Object.prototype.hasOwnProperty.call(response, "JWT Error")) {
                 props.JWTSetter("");
                 return false;
@@ -125,7 +125,7 @@ function RecentProblemsRater(props) {
             const transaction = { update: [dataToUpdate] };
             gridApi.applyTransaction(transaction);
         }
-    }
+    };
 
     const handleRatingChange = async (event, problemId) => {
         const updatedInBackend = responseHandler(() => API.updateDifficultyRating(props.JWT, problemId, event.target.value));

--- a/client/src/pages/ProfilePage/components/UnlinkCodeforcesAccount.jsx
+++ b/client/src/pages/ProfilePage/components/UnlinkCodeforcesAccount.jsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import API from "../../../api";
+import propTypes from "prop-types";
+
+UnlinkCodeforcesAccount.propTypes = {
+    JWT: propTypes.string.isRequired,
+    JWTSetter: propTypes.func.isRequired,
+};
+
+function UnlinkCodeforcesAccount(props) {
+    const [statusMsg, setStatusMsg] = useState("");
+    const handleUnlink = async () => {
+        const response = await API.unlinkHandle(props.JWT).then((response) => response.json());
+        if (Object.prototype.hasOwnProperty.call(response, "JWT Error")) {
+            props.JWTSetter("");
+        }
+
+        if (response.status === "OK") {
+            const modalInstance = bootstrap.Modal.getInstance(document.getElementById("unlinkModal"));
+            if (modalInstance) {
+                modalInstance.hide();
+            }
+        } else {
+            setStatusMsg("Unlinking failed");
+        }
+    };
+
+    return (
+        <>
+            <button
+                className="btn btn-sm btn-outline-dark"
+                id="profilePageHandleUnlink"
+                data-bs-toggle="modal"
+                data-bs-target="#unlinkModal"
+            >
+                Unlink
+            </button>
+
+            <div className="modal fade" id="unlinkModal" tabIndex="-1">
+                <div className="modal-dialog">
+                    <div className="modal-content">
+                        <div className="modal-header">
+                            <h1 className="modal-title fs-5">Unlink Codeforces Account</h1>
+                            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div className="modal-body">
+                            <div className="text-danger">{statusMsg}</div>
+                            Are you sure you want to do this?
+                        </div>
+                        <div className="modal-footer">
+                            <button type="button" className="btn btn-sm btn-outline-danger" data-bs-dismiss="modal">
+                                No
+                            </button>
+                            <button type="button" className="btn btn-sm btn-outline-success" onClick={handleUnlink}>
+                                Yes
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default UnlinkCodeforcesAccount;

--- a/client/src/public/favicon.svg
+++ b/client/src/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="bi bi-code-slash" viewBox="0 0 16 16">
+	<path d="M10.478 1.647a.5.5 0 1 0-.956-.294l-4 13a.5.5 0 0 0 .956.294zM4.854 4.146a.5.5 0 0 1 0 .708L1.707 8l3.147 3.146a.5.5 0 0 1-.708.708l-3.5-3.5a.5.5 0 0 1 0-.708l3.5-3.5a.5.5 0 0 1 .708 0m6.292 0a.5.5 0 0 0 0 .708L14.293 8l-3.147 3.146a.5.5 0 0 0 .708.708l3.5-3.5a.5.5 0 0 0 0-.708l-3.5-3.5a.5.5 0 0 0-.708 0"/>
+	<style>
+		.bi.bi-code-slash path {
+			fill: black;
+		}
+		@media(prefers-color-scheme: dark) {
+			.bi.bi-code-slash path {
+				fill: white;
+			}
+		}
+  	</style>
+</svg>

--- a/server/core/data.js
+++ b/server/core/data.js
@@ -47,8 +47,8 @@ class Data {
                 where: { username },
                 data: {
                     submissions: 0,
-                    AC: 0
-                }
+                    AC: 0,
+                },
             });
 
             const submissions = await prisma.Submission.findMany({
@@ -145,7 +145,7 @@ class Data {
                 if (!ratingsAC[problemStatus.problem.rating]) {
                     ratingsAC[problemStatus.problem.rating] = 0;
                 }
-                
+
                 ratingsFrequency[problemStatus.problem.rating]++;
                 if (problemStatus.AC > 0) {
                     ratingsAC[problemStatus.problem.rating]++;
@@ -153,7 +153,7 @@ class Data {
             }
 
             // count the number of submissions and AC over the last 60 days
-            const past60DaySubmissions = Array(60).fill(0)
+            const past60DaySubmissions = Array(60).fill(0);
             const past60DayAC = Array(60).fill(0);
             const sortedSubmissions = await prisma.Submission.findMany({
                 where: {
@@ -450,7 +450,42 @@ class Data {
         try {
             await prisma.UserProblemStatus.update({
                 where: { username_problemId: { username, problemId } },
-                data: { markedForRevision: markToRevise }
+                data: { markedForRevision: markToRevise },
+            });
+        } catch (error) {
+            return error;
+        }
+    }
+
+    /*
+    Delete all CF data for user
+    */
+    static async deleteData(username) {
+        try {
+            await prisma.Submission.deleteMany({
+                where: { authorUsername: username } 
+            });
+            await prisma.UserProblemStatus.deleteMany({
+                where: { username }
+            });
+
+            await prisma.User.update({
+                where: { username },
+                data: {
+                    handle: null,
+                    rating: 0, 
+                    estimatedRating: 0,
+                    problemsAC: 0,
+                    totalSubmissions: 0,
+                    totalAC: 0, 
+                    tagsFrequency: {},
+                    tagsDifficulty: {}, 
+                    ratingsAC: {},
+                    assignedProblemId: null,
+                    recentSubmissions: [],
+                    recentAC: [],
+                    lastUpdated: new Date().toISOString() 
+                }
             });
         } catch (error) {
             return error;

--- a/server/core/jobs.js
+++ b/server/core/jobs.js
@@ -10,7 +10,6 @@ const cfQueue = new Queue("codeforces queue", {
     connection: redisConnection,
 });
 
-// update data at 12 AM
 cfQueue.add("update problems", { fn: "UPDATE_PROBLEM" }, { repeat: { cron: "0 0 * * *" }, priority: 1 });
 cfQueue.add("update contests", { fn: "UPDATE_CONTEST" }, { repeat: { cron: "0 0 * * *" }, priority: 1 });
 
@@ -123,7 +122,7 @@ const linkCF = async (username, handle) => {
     });
 
     // create a new job to make sure user data is fresh
-    cfQueue.add("update user", { fn: "UPDATE_USER", username }, { repeat: { cron: "0 0 * * *" }, priority: 1 });
+    cfQueue.add("update user", { fn: "UPDATE_USER", username }, { repeat: { cron: "0 0 * * *" }, priority: 1, jobId: `update-user-${handle}`});
 
     SSE.sendUsernameUpdate(username, {
         job: "LINK_USER",


### PR DESCRIPTION
## Description
Although users aren't allowed to change their handle 7 days after registration, there is a slot of time between late December and early January where users are allowed to change their handle once a year. 

This PR fixes this edge case by allowing users to disconnect their GitHub account from their Codeforces handle so that they can link it to their new handle.

## Milestones

## Resources
- https://docs.bullmq.io/guide/jobs/repeatable - Docs on removing old user handle jobs and having unique jobs with jobId.
- https://blog.logrocket.com/understanding-react-useeffect-cleanup-function/ - Clean up function to prevent bad API calls to backend when user unlinks.
## Test Plan
https://www.loom.com/share/e6771bdcc4f245009acab0b4b5d92da6